### PR TITLE
Chore - Improve PWA Experience

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,12 @@
 {
   "short_name": "Meteorite",
   "name": "Meteorite – Smarter GitHub Notifications",
+  "description": "Smarter GitHub notifications. Organize and score notifications based on importance and relevance.",
+  "start_url": "/login",
+  "scope": "/",
+  "display": "standalone",
+  "theme_color": "#2f343e",
+  "background_color": "#fffefc",
   "icons": [
     {
       "src": "new-app-icon-rounded.png",
@@ -42,9 +48,5 @@
       "sizes": "512x512",
       "type": "image/png"
     }
-  ],
-  "start_url": "/login",
-  "display": "standalone",
-  "theme_color": "#2f343e",
-  "background_color": "#fffefc"
+  ]
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -43,7 +43,7 @@
       "type": "image/png"
     }
   ],
-  "start_url": "/",
+  "start_url": "/login",
   "display": "standalone",
   "theme_color": "#2f343e",
   "background_color": "#fffefc"


### PR DESCRIPTION
# Scope

This PR aims to improve the PWA experience by:

 - Updating the app manifest's `start_url` to be the `/login` route, so that you're not brought to the marketing page on launch
 - Updating the app manifest to add a description, a "scope", and organizing the meta before the icon list

The first detail is most important, as opening the installed app currently brings you to the `/` route, which is the marketing page. That makes little sense, as if you've installed the app you likely already know what it is. The `/login` page seemed like a logical choice here, as it will either present the login page or redirect the user to the proper application experience.

The other details are mostly for improving the experience in an app launcher and app search on a given OS, and for improving the grouping of meta-data in the manifest.