### PR TITLE
Bugfix: Wording (Relevent -> Relevant)

### DIFF
--- a/src/pages/NotificationsRedesign/redesign/utils.js
+++ b/src/pages/NotificationsRedesign/redesign/utils.js
@@ -277,7 +277,7 @@ export function prettify(n) {
 export function titleOfMode(mode) {
   switch (mode) {
     case Mode.ALL:
-      return 'All Relevent Threads';
+      return 'All Relevant Threads';
     case Mode.HOT:
       return 'Hot Threads';
     case Mode.COMMENTS:
@@ -292,7 +292,7 @@ export function titleOfMode(mode) {
 export function titleOfFilter(filter) {
   switch (filter) {
     case Filters.PARTICIPATING:
-      return 'All Relevent';
+      return 'All Relevant';
     case Filters.SUBSCRIBED:
       return 'Subscribed';
     case Filters.COMMENT:


### PR DESCRIPTION
I saw the typo on the landing page in the product screenshot, you might want to update it there as well.

https://whichiscorrect.com/relevant-or-relevent/